### PR TITLE
Bugfix: Correct DATETIME_FORMAT to show minute not month.

### DIFF
--- a/bhtom2/settings.py
+++ b/bhtom2/settings.py
@@ -234,7 +234,7 @@ USE_L10N = False
 
 USE_TZ = True
 
-DATETIME_FORMAT = 'Y-m-d H:m:s'
+DATETIME_FORMAT = 'Y-m-d H:i:s'
 DATE_FORMAT = 'Y-m-d'
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
Hey all! I saw your issue with TOMToolkit (https://github.com/TOMToolkit/tom_base/issues/638) and wanted to submit the fix to correct the datetimestamp. 

`m` is month, `i` is minute. It was showing the month of the datetime when displayed.

Cheers!